### PR TITLE
build: add Linux ARM64 packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "build": "npm run typecheck && electron-vite build",
     "build:win": "npm run build && electron-builder --win --config --publish always",
     "build:mac": "npm run build && electron-builder --mac --config --publish always",
-    "build:linux": "npm run build && electron-builder --linux --config --publish always"
+    "build:linux": "npm run build && electron-builder --linux --config --publish always",
+    "build:linux:arm64": "npm run build && electron-builder --linux AppImage --arm64 --config --publish never && npm run build:linux:arm64:deb",
+    "build:linux:arm64:deb": "ts-node -P tsconfig.scripts.json scripts/build-linux-arm64-deb.ts"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",

--- a/scripts/build-linux-arm64-deb.ts
+++ b/scripts/build-linux-arm64-deb.ts
@@ -1,0 +1,190 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+type PackageJson = {
+  name: string;
+  version: string;
+  description: string;
+  homepage?: string;
+};
+
+type CommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+const PRODUCT_NAME = 'Civitai Link';
+const MAINTAINER = 'civitai.com';
+const ARCH = 'arm64';
+const DEBIAN_DEPENDS = [
+  'libgtk-3-0',
+  'libnotify4',
+  'libnss3',
+  'libxss1',
+  'libxtst6',
+  'xdg-utils',
+  'libatspi2.0-0',
+  'libuuid1',
+  'libsecret-1-0',
+];
+const DEBIAN_RECOMMENDS = ['libappindicator3-1'];
+
+const repoRoot = resolve(__dirname, '..');
+const packageJson = JSON.parse(
+  readFileSync(join(repoRoot, 'package.json'), 'utf8'),
+) as PackageJson;
+const unpackedDir = join(repoRoot, 'dist', 'linux-arm64-unpacked');
+const stagingDir = join(repoRoot, 'dist', 'deb-arm64');
+const outputDeb = join(
+  repoRoot,
+  'dist',
+  `${packageJson.name}_${packageJson.version}_${ARCH}.deb`,
+);
+const installDir = join(stagingDir, 'opt', PRODUCT_NAME);
+
+if (process.platform !== 'linux') {
+  throw new Error('ARM64 .deb packaging requires Linux and dpkg-deb.');
+}
+
+if (!existsSync(unpackedDir)) {
+  throw new Error(
+    `Missing ${unpackedDir}. Run electron-builder with "--linux AppImage --arm64" first.`,
+  );
+}
+
+rmSync(stagingDir, { recursive: true, force: true });
+rmSync(outputDeb, { force: true });
+
+mkdirSync(dirname(installDir), { recursive: true });
+cpSync(unpackedDir, installDir, { recursive: true, preserveTimestamps: true });
+
+const chromeSandbox = join(installDir, 'chrome-sandbox');
+if (existsSync(chromeSandbox)) {
+  chmodSync(chromeSandbox, 0o4755);
+}
+
+writeLauncher();
+writeDesktopEntry();
+writeIcon();
+writeControlFile();
+run('dpkg-deb', ['--build', '--root-owner-group', stagingDir, outputDeb]);
+
+console.log(`Built ${outputDeb}`);
+
+function writeLauncher(): void {
+  const binDir = join(stagingDir, 'usr', 'bin');
+  mkdirSync(binDir, { recursive: true });
+  symlinkSync(
+    `/opt/${PRODUCT_NAME}/${packageJson.name}`,
+    join(binDir, packageJson.name),
+  );
+}
+
+function writeDesktopEntry(): void {
+  const desktopPath = join(
+    stagingDir,
+    'usr',
+    'share',
+    'applications',
+    `${packageJson.name}.desktop`,
+  );
+  mkdirSync(dirname(desktopPath), { recursive: true });
+  writeFileSync(
+    desktopPath,
+    [
+      '[Desktop Entry]',
+      `Name=${PRODUCT_NAME}`,
+      `Comment=${packageJson.description}`,
+      `Exec="/opt/${PRODUCT_NAME}/${packageJson.name}" %U`,
+      'Terminal=false',
+      'Type=Application',
+      `Icon=${packageJson.name}`,
+      `StartupWMClass=${PRODUCT_NAME}`,
+      'Categories=Utility;',
+      '',
+    ].join('\n'),
+  );
+}
+
+function writeIcon(): void {
+  const sourceIcon = join(repoRoot, 'build', 'icon.png');
+  if (!existsSync(sourceIcon)) {
+    return;
+  }
+
+  const iconPath = join(
+    stagingDir,
+    'usr',
+    'share',
+    'icons',
+    'hicolor',
+    '512x512',
+    'apps',
+    `${packageJson.name}.png`,
+  );
+  mkdirSync(dirname(iconPath), { recursive: true });
+  cpSync(sourceIcon, iconPath);
+}
+
+function writeControlFile(): void {
+  const controlPath = join(stagingDir, 'DEBIAN', 'control');
+  mkdirSync(dirname(controlPath), { recursive: true });
+
+  const installedSize = run('du', ['-sk', stagingDir])
+    .stdout.trim()
+    .split(/\s+/)[0];
+  const homepage = packageJson.homepage ?? 'https://www.civitai.com';
+
+  writeFileSync(
+    controlPath,
+    [
+      `Package: ${packageJson.name}`,
+      `Version: ${packageJson.version}`,
+      'Section: utils',
+      'Priority: optional',
+      `Architecture: ${ARCH}`,
+      `Installed-Size: ${installedSize}`,
+      `Maintainer: ${MAINTAINER}`,
+      `Homepage: ${homepage}`,
+      `Depends: ${DEBIAN_DEPENDS.join(', ')}`,
+      `Recommends: ${DEBIAN_RECOMMENDS.join(', ')}`,
+      `Description: ${packageJson.description}`,
+      ` ${PRODUCT_NAME} packaged for Linux ARM64 from the upstream source build.`,
+      '',
+    ].join('\n'),
+  );
+}
+
+function run(command: string, args: string[]): CommandResult {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${command} ${args.join(' ')}`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}


### PR DESCRIPTION
## Summary

- add `build:linux:arm64` for producing Linux ARM64 AppImage and Debian artifacts
- add a native `dpkg-deb` packaging script for `civitai-link_1.20.5_arm64.deb`
- keep the existing Linux build script unchanged for current release behavior

## Problem

On an ARM64 Linux host, `electron-builder --linux --arm64` can build the ARM64 AppImage, but the Debian packaging step fails because electron-builder downloads and executes the `fpm-1.9.3-2.3.1-linux-x86` helper:

```text
cannot execute binary file: Exec format error
```

That blocks producing a `.deb` directly on ARM64 systems such as NVIDIA DGX-style ARM64 Linux hosts.

## Alternative Used

This keeps electron-builder for the parts that work well on ARM64:

- compile with the existing `npm run build`
- package the ARM64 AppImage with `electron-builder --linux AppImage --arm64`

Then it builds the ARM64 `.deb` with native Debian tooling:

- stages `dist/linux-arm64-unpacked` under `/opt/Civitai Link`
- adds the `/usr/bin/civitai-link` launcher symlink
- adds the desktop entry and icon
- writes Debian control metadata with `Architecture: arm64`
- runs `dpkg-deb --build --root-owner-group`

## Validation

Ran on an ARM64 Linux machine:

```bash
fnm exec --using=20.13.1 npm ci
fnm exec --using=20.13.1 npm run build:linux:arm64
fnm exec --using=20.13.1 npx prettier --check package.json scripts/build-linux-arm64-deb.ts
dpkg-deb -I dist/civitai-link_1.20.5_arm64.deb
file dist/civitai-link-1.20.5.AppImage dist/civitai-link_1.20.5_arm64.deb
```

The generated Debian package reports `Architecture: arm64`; the AppImage is an ARM aarch64 ELF executable.
